### PR TITLE
Populate gitignore with contents from svn:ignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
-*.class
-
-# Package Files #
-*.jar
-*.war
-*.ear
+target
+.classpath
+.project
+.settings
+*.iml
+*.ipr
+*.iws


### PR DESCRIPTION
Use contents from google code repo's svn:ignore for .gitignore.  It's more comprehensive than the default github java project one that is in JRugged now.
