### PR TITLE
Remove log4j as a dependency

### DIFF
--- a/jrugged-aspects/src/test/java/org/fishwife/jrugged/aspects/TestCircuitBreakerAspect.java
+++ b/jrugged-aspects/src/test/java/org/fishwife/jrugged/aspects/TestCircuitBreakerAspect.java
@@ -207,8 +207,10 @@ public class TestCircuitBreakerAspect {
 
     private static ProceedingJoinPoint createPjpMock(Signature mockSignature, int times) {
         ProceedingJoinPoint mockPjp = createMock(ProceedingJoinPoint.class);
-        expect(mockPjp.getTarget()).andReturn("Target").times(times);
-        expect(mockPjp.getSignature()).andReturn(mockSignature).times(times);
+        // XXX: the following two interactions are for logging, so they may happen
+        //      0 or n times, pending logging configuration
+        expect(mockPjp.getTarget()).andReturn("Target").times(0, times);
+        expect(mockPjp.getSignature()).andReturn(mockSignature).times(0, times);
         return mockPjp;
     }
 

--- a/jrugged-aspects/src/test/java/org/fishwife/jrugged/aspects/TestPerformanceMonitorAspect.java
+++ b/jrugged-aspects/src/test/java/org/fishwife/jrugged/aspects/TestPerformanceMonitorAspect.java
@@ -55,8 +55,10 @@ public class TestPerformanceMonitorAspect {
     private static ProceedingJoinPoint createPjpMock(Signature mockSignature,
                                                      int times) {
         ProceedingJoinPoint mockPjp = createMock(ProceedingJoinPoint.class);
-        expect(mockPjp.getTarget()).andReturn("Target").times(times);
-        expect(mockPjp.getSignature()).andReturn(mockSignature).times(times);
+        // XXX: the following two interactions are for logging, so they may happen
+        //      0 or n times, pending logging configuration
+        expect(mockPjp.getTarget()).andReturn("Target").times(0, times);
+        expect(mockPjp.getSignature()).andReturn(mockSignature).times(0, times);
         return mockPjp;
     }
 

--- a/pom.xml
+++ b/pom.xml
@@ -46,41 +46,7 @@
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
-            <version>1.5.0</version>
-        </dependency>
-        <dependency>
-            <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-log4j12</artifactId>
-            <version>1.5.0</version>
-            <exclusions>
-                <exclusion>
-                    <groupId>log4j</groupId>
-                    <artifactId>log4j</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
-        <dependency>
-            <groupId>log4j</groupId>
-            <artifactId>log4j</artifactId>
-            <version>1.2.15</version>
-            <exclusions>
-                <exclusion>
-                    <groupId>javax.mail</groupId>
-                    <artifactId>mail</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>javax.jms</groupId>
-                    <artifactId>jms</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>com.sun.jdmk</groupId>
-                    <artifactId>jmxtools</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>com.sun.jmx</groupId>
-                    <artifactId>jmxri</artifactId>
-                </exclusion>
-            </exclusions>
+            <version>1.7.0</version>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
Currently JRugged leaks log4j into end users' projects as a transient dependency.  While this is generally overlooked it is often not desired.

Up slf4j version to 1.7.0 so it defaults to the NOP binding if no other bindings are available, allowing the log4j binding to be taken out of the dependencies.  The NOP default behaviour is available since 1.6.0, so that version can be tweaked if wanted.

I'm not sure whether or not there should be a binding specified for the test scope.  My natural inclination is not to until there is demand, but there may also be some history there that I am unaware of.
