### PR TITLE
Replace google code links with new github ones

### DIFF
--- a/jrugged-aspects/pom.xml
+++ b/jrugged-aspects/pom.xml
@@ -26,7 +26,7 @@
 	<artifactId>jrugged-aspects</artifactId>
 	<packaging>jar</packaging>
 	<name>jrugged-aspects</name>
-	<url>http://code.google.com/p/jrugged/</url>
+	<url>https://github.com/Comcast/jrugged</url>
 
 	<dependencies>
 		<dependency>

--- a/jrugged-aspects/src/main/java/org/fishwife/jrugged/aspects/package.html
+++ b/jrugged-aspects/src/main/java/org/fishwife/jrugged/aspects/package.html
@@ -30,7 +30,7 @@ wrapped in {@link org.fishwife.jrugged.CircuitBreaker} or {@link org.fishwife.jr
 
 For overviews, tutorials, examples, guides, and tool documentation, please see:
 <ul>
-  <li><a href="http://code.google.com/p/jrugged/">JRugged Project Home Page</a>
+  <li><a href="https://github.com/Comcast/jrugged">JRugged Project Home Page</a>
 </ul>
 
 <!-- Put @see and @since tags down here. -->

--- a/jrugged-core/pom.xml
+++ b/jrugged-core/pom.xml
@@ -26,5 +26,5 @@
 	<artifactId>jrugged-core</artifactId>
 	<packaging>jar</packaging>
 	<name>jrugged-core</name>
-	<url>http://code.google.com/p/jrugged/</url>
+	<url>https://github.com/Comcast/jrugged</url>
 </project>

--- a/jrugged-core/src/main/java/org/fishwife/jrugged/package.html
+++ b/jrugged-core/src/main/java/org/fishwife/jrugged/package.html
@@ -57,7 +57,7 @@ status pages as desired.
 
 For overviews, tutorials, examples, guides, and tool documentation, please see:
 <ul>
-  <li><a href="http://code.google.com/p/jrugged/">JRugged Project Home Page</a>
+  <li><a href="https://github.com/Comcast/jrugged">JRugged Project Home Page</a>
 </ul>
 
 <!-- Put @see and @since tags down here. -->

--- a/jrugged-examples/pom.xml
+++ b/jrugged-examples/pom.xml
@@ -27,7 +27,7 @@
     <packaging>war</packaging>
     <version>3.0.6-SNAPSHOT</version>
     <name>jrugged-examples</name>
-    <url>http://code.google.com/p/jrugged</url>
+    <url>https://github.com/Comcast/jrugged</url>
 
     <prerequisites>
         <maven>2.0.6</maven>

--- a/jrugged-spring/pom.xml
+++ b/jrugged-spring/pom.xml
@@ -26,7 +26,7 @@
 	<artifactId>jrugged-spring</artifactId>
 	<packaging>jar</packaging>
 	<name>jrugged-spring</name>
-	<url>http://code.google.com/p/jrugged/</url>
+	<url>https://github.com/Comcast/jrugged</url>
 
     <properties>
         <spring.version>3.0.5.RELEASE</spring.version>

--- a/pom.xml
+++ b/pom.xml
@@ -21,12 +21,12 @@
     <packaging>pom</packaging>
     <version>3.0.6-SNAPSHOT</version>
     <name>jrugged</name>
-    <url>http://code.google.com/p/jrugged/</url>
+    <url>https://github.com/Comcast/jrugged</url>
 
     <scm>
-        <connection>scm:svn:https://jrugged.googlecode.com/svn/</connection>
-        <developerConnection>scm:svn:https://jrugged.googlecode.com/svn/</developerConnection>
-        <url>https://jrugged.googlecode.com/svn/tags/jrugged-3.0.3</url>
+        <connection>scm:git:git://github.com/Comcast/jrugged.git</connection>
+        <developerConnection>scm:git:git://github.com/Comcast/jrugged.git</developerConnection>
+        <url>git://github.com/Comcast/jrugged.git</url>
     </scm>
 
     <dependencies>


### PR DESCRIPTION
This should be the last of the google code references in the project,
completing that part of the migration.
