### PR TITLE
Add service name to RolledUpMonitoredService reasons.

### DIFF
--- a/jrugged-core/src/main/java/org/fishwife/jrugged/RolledUpMonitoredService.java
+++ b/jrugged-core/src/main/java/org/fishwife/jrugged/RolledUpMonitoredService.java
@@ -70,7 +70,9 @@ public class RolledUpMonitoredService implements MonitoredService {
             Status status = serviceStatus.getStatus();
 
             if (statusIsNotUp(status)) {
-                reasons.addAll(serviceStatus.getReasons());
+                for (String reason : serviceStatus.getReasons()) {
+                    reasons.add(serviceStatus.getName() + ":" + reason);
+                }
             }
 
             if (status.getValue() < criticalStatus.getValue()) {
@@ -85,7 +87,9 @@ public class RolledUpMonitoredService implements MonitoredService {
             Status status = serviceStatus.getStatus();
 
             if (statusIsNotUp(status)) {
-                reasons.addAll(serviceStatus.getReasons());
+                for (String reason : serviceStatus.getReasons()) {
+                    reasons.add(serviceStatus.getName() + ":" + reason);
+                }
                 result = Status.DEGRADED;
             }
         }

--- a/jrugged-core/src/test/java/org/fishwife/jrugged/TestRolledUpMonitoredService.java
+++ b/jrugged-core/src/test/java/org/fishwife/jrugged/TestRolledUpMonitoredService.java
@@ -79,7 +79,7 @@ public class TestRolledUpMonitoredService {
 
         assertEquals(ROLLEDUP_SERVICE_NAME, serviceStatus.getName());
         assertEquals(serviceStatus.getStatus(), Status.DEGRADED);
-        assertTrue(serviceStatus.getReasons().contains(SERVICE_1_REASON));
+        assertTrue(serviceStatus.getReasons().contains(SERVICE_1_NAME + ":" + SERVICE_1_REASON));
     }
 
     @Test
@@ -94,7 +94,7 @@ public class TestRolledUpMonitoredService {
 
         assertEquals(ROLLEDUP_SERVICE_NAME, serviceStatus.getName());
         assertEquals(serviceStatus.getStatus(), Status.DEGRADED);
-        assertTrue(serviceStatus.getReasons().contains(SERVICE_2_REASON));
+        assertTrue(serviceStatus.getReasons().contains(SERVICE_2_NAME + ":" + SERVICE_2_REASON));
     }
 
     @Test
@@ -110,8 +110,8 @@ public class TestRolledUpMonitoredService {
 
         assertEquals(ROLLEDUP_SERVICE_NAME, serviceStatus.getName());
         assertEquals(serviceStatus.getStatus(), Status.DEGRADED);
-        assertTrue(serviceStatus.getReasons().contains(SERVICE_1_REASON));
-        assertTrue(serviceStatus.getReasons().contains(SERVICE_2_REASON));
+        assertTrue(serviceStatus.getReasons().contains(SERVICE_1_NAME + ":" + SERVICE_1_REASON));
+        assertTrue(serviceStatus.getReasons().contains(SERVICE_2_NAME + ":" + SERVICE_2_REASON));
     }
 
     @Test
@@ -126,7 +126,7 @@ public class TestRolledUpMonitoredService {
 
         assertEquals(ROLLEDUP_SERVICE_NAME, serviceStatus.getName());
         assertEquals(serviceStatus.getStatus(), Status.DEGRADED);
-        assertTrue(serviceStatus.getReasons().contains(SERVICE_2_REASON));
+        assertTrue(serviceStatus.getReasons().contains(SERVICE_2_NAME + ":" + SERVICE_2_REASON));
     }
 
     @Test


### PR DESCRIPTION
This addresses issue #15 in the Issues list.

If a RolledUpMonitoredService has a status that is not UP then
getReasons can be used to determine the cause.  Calling getReasons()
enumerates the reason for each child service that is not UP.  In
many cases the child services are CircuitBreakers.

The current behavior for getReasons() lists only 'Open' or
'Send Probe Request' for each CircuitBreaker.  It does not include
any identification for which CircuitBreaker is affected.

This change adds the service name as a prefix for each reason,
making it clear which service is causing the Non-UP status for the
RolledUpMonitoredService.

Before Change:  getReasons() might return
  { "Open", "Send Probe Request" }

After Chnage: getReasons() might return
  { "Service 1:Open", "Service 2:Send Probe Request" }
