### PR TITLE
add minimum request threshold to PercentErrPerTimeFailureInterpreter

### DIFF
--- a/jrugged-core/src/main/java/org/fishwife/jrugged/PercentErrPerTimeFailureInterpreter.java
+++ b/jrugged-core/src/main/java/org/fishwife/jrugged/PercentErrPerTimeFailureInterpreter.java
@@ -30,6 +30,7 @@ public final class PercentErrPerTimeFailureInterpreter implements FailureInterpr
     private Set<Class<? extends Throwable>> ignore = new HashSet<Class<? extends Throwable>>();
     private int percent = 0;
     private long windowMillis = 0;
+    private int requestThreshold = 0;
 
     // tracks times when exceptions occurred
     private List<Long> errorTimes = new LinkedList<Long>();
@@ -177,7 +178,7 @@ public final class PercentErrPerTimeFailureInterpreter implements FailureInterpr
 
             // Trip if the number of errors over the total of requests over the same period
             // is over the percentage limit.
-            return (((double)numberOfErrorsAfter / (double)windowRequests) * 100d >= percent);
+            return windowRequests >= requestThreshold && (((double) numberOfErrorsAfter / (double) windowRequests) * 100d >= percent);
         }
         return true;
 	}
@@ -275,5 +276,16 @@ public final class PercentErrPerTimeFailureInterpreter implements FailureInterpr
      */
     public void setRequestCounter(RequestCounter rc) {
         requestCounter = rc;
+    }
+
+    /**
+     * Sets the threshold at which the number of requests in the current window must be above in order for the breaker
+     * to trip. This is intended to prevent the breaker from being opened if the first request into this interpreter is
+     * a failure.
+     *
+     * @param requestThreshold The threshold to set, defaults to 0
+     */
+    public void setRequestThreshold(int requestThreshold) {
+        this.requestThreshold = requestThreshold;
     }
 }

--- a/jrugged-core/src/test/java/org/fishwife/jrugged/TestPercentErrPerTimeFailureInterpreter.java
+++ b/jrugged-core/src/test/java/org/fishwife/jrugged/TestPercentErrPerTimeFailureInterpreter.java
@@ -190,5 +190,49 @@ public class TestPercentErrPerTimeFailureInterpreter {
             assertFalse(pept.shouldTrip(e));
         }
     }
+
+    @Test
+    public void testDoesNotTripWhenRequestCountInWindowIsLessThanThreshold() throws Exception {
+        PercentErrPerTimeFailureInterpreter pept = new PercentErrPerTimeFailureInterpreter();
+        RequestCounter rc = new RequestCounter();
+        pept.setRequestCounter(rc);
+        pept.setPercent(51);
+        pept.setWindowMillis(250000);
+        pept.setRequestThreshold(8);
+
+        try {
+            rc.invoke(new DummyRunnable());
+            rc.invoke(new DummyRunnable());
+            rc.invoke(new DummyRunnable());
+        } catch (Exception e) {
+            pept.shouldTrip(e);
+        }
+
+        try {
+            rc.invoke(new DummyRunnableException());
+        } catch (Exception e) {
+            assertFalse(pept.shouldTrip(e));
+        }
+
+        try {
+            rc.invoke(new DummyRunnableException());
+        } catch (Exception e) {
+            assertFalse(pept.shouldTrip(e));
+        }
+
+        try {
+            rc.invoke(new DummyRunnableException());
+        } catch (Exception e) {
+            assertFalse(pept.shouldTrip(e));
+        }
+
+        //seventh total request, fourth failure, pushes percentage to 57%, but should not trip because total number
+        //of requests is below threshold of 8
+        try {
+            rc.invoke(new DummyRunnableException());
+        } catch (Exception e) {
+            assertFalse(pept.shouldTrip(e));
+        }
+    }
 }
 


### PR DESCRIPTION
When configured, the interpreter will not trip if the number of requests in the window is below the threshold. The intention is to prevent the interpreter from tripping if the first request in a window is a failure.
