### PR TITLE
Adding "target" element to CircuitBreaker annotation.

### DIFF
--- a/jrugged-aspects/src/main/java/org/fishwife/jrugged/aspects/CircuitBreaker.java
+++ b/jrugged-aspects/src/main/java/org/fishwife/jrugged/aspects/CircuitBreaker.java
@@ -43,6 +43,14 @@ public @interface CircuitBreaker {
     Class<? extends Throwable>[] ignore() default {};
 
     /**
+     * Exception types that the {@link
+     * org.fishwife.jrugged.CircuitBreaker} will consider as failure
+     * and may cause tripping if it reaches the limit.
+     * @return the Exception types.
+     */
+    Class<? extends Throwable>[] target() default {};
+    
+    /**
      * Specifies the length of the measurement window for failure
      * tolerances in milliseconds.  i.e. if <code>limit</code>
      * failures occur within <code>windowMillis</code> milliseconds,

--- a/jrugged-aspects/src/main/java/org/fishwife/jrugged/aspects/CircuitBreakerAspect.java
+++ b/jrugged-aspects/src/main/java/org/fishwife/jrugged/aspects/CircuitBreakerAspect.java
@@ -87,6 +87,7 @@ public class CircuitBreakerAspect {
             DefaultFailureInterpreter dfi =
                     new DefaultFailureInterpreter(
                             circuitBreakerAnnotation.ignore(),
+                            circuitBreakerAnnotation.target(),
                             circuitBreakerAnnotation.limit(),
                             circuitBreakerAnnotation.windowMillis());
 

--- a/jrugged-aspects/src/test/java/org/fishwife/jrugged/aspects/TestCircuitBreakerAspect.java
+++ b/jrugged-aspects/src/test/java/org/fishwife/jrugged/aspects/TestCircuitBreakerAspect.java
@@ -54,6 +54,9 @@ public class TestCircuitBreakerAspect {
         @SuppressWarnings("unchecked")
         Class<Throwable>[] ignores = new Class[0];
         expect(mockAnnotation.ignore()).andReturn(ignores);
+        @SuppressWarnings("unchecked")
+        Class<Throwable>[] targets = new Class[0];
+        expect(mockAnnotation.target()).andReturn(targets);
 
         replay(mockAnnotation);
         replay(mockSignature);
@@ -84,6 +87,9 @@ public class TestCircuitBreakerAspect {
         @SuppressWarnings("unchecked")
         Class<Throwable>[] ignores = new Class[0];
         expect(otherMockAnnotation.ignore()).andReturn(ignores);
+        @SuppressWarnings("unchecked")
+        Class<Throwable>[] targets = new Class[0];
+        expect(otherMockAnnotation.target()).andReturn(targets);
         replay(otherMockAnnotation);
 
         // Test monitor with another circuit breaker.

--- a/jrugged-core/src/main/java/org/fishwife/jrugged/DefaultFailureInterpreter.java
+++ b/jrugged-core/src/main/java/org/fishwife/jrugged/DefaultFailureInterpreter.java
@@ -28,6 +28,7 @@ import java.util.Set;
 public final class DefaultFailureInterpreter implements FailureInterpreter {
 
     private Set<Class<? extends Throwable>> ignore = new HashSet<Class<? extends Throwable>>();
+    private Set<Class<? extends Throwable>> target = new HashSet<Class<? extends Throwable>>();
     private int limit = 0;
     private long windowMillis = 0;
 
@@ -36,12 +37,16 @@ public final class DefaultFailureInterpreter implements FailureInterpreter {
 	@SuppressWarnings("unchecked")
 	private static Class<? extends Throwable>[] defaultIgnore = 
 		new Class[0];
+	
+	@SuppressWarnings("unchecked")
+    private static Class<? extends Throwable>[] defaultTarget = 
+        new Class[0];
 
     /**
      * Default constructor. Any {@link Throwable} will cause the breaker to trip.
      */
     public DefaultFailureInterpreter() {
-		setIgnore(defaultIgnore);
+        this(defaultIgnore, defaultTarget, 0, 0);
 	}
 
     /**
@@ -55,10 +60,7 @@ public final class DefaultFailureInterpreter implements FailureInterpreter {
      * @param windowMillis length of the window in milliseconds
      */
 	public DefaultFailureInterpreter(int limit, long windowMillis) {
-		setIgnore(defaultIgnore);
-		setLimit(limit);
-		setWindowMillis(windowMillis);
-		initCounter();
+	    this(defaultIgnore, defaultTarget, limit, windowMillis);
 	}
 
     /**
@@ -71,7 +73,7 @@ public final class DefaultFailureInterpreter implements FailureInterpreter {
      *   subclass of one of these classes will be ignored. 
      */
 	public DefaultFailureInterpreter(Class<? extends Throwable>[] ignore) {
-		setIgnore(ignore);
+		this(ignore, defaultTarget, 0, 0);
 	}
 
     /**
@@ -80,6 +82,10 @@ public final class DefaultFailureInterpreter implements FailureInterpreter {
      * @param ignore an array of {@link Throwable} classes that will
      *   be ignored. Any given <code>Throwable</code> that is a
      *   subclass of one of these classes will be ignored. 
+     * @param target an array of {@link Throwable} classes that will
+     *   be considered as failures. Any given <code>Throwable</code>
+     *   that is a subclass of one of these classes will be considered
+     *   as failures.
      * @param limit the number of failures that will be tolerated
      *   (i.e. the number of failures has to be strictly <em>greater
      *   than</em> this number in order to trip the breaker). For
@@ -88,8 +94,10 @@ public final class DefaultFailureInterpreter implements FailureInterpreter {
      * @param windowMillis length of the window in milliseconds
      */
 	public DefaultFailureInterpreter(Class<? extends Throwable>[] ignore,
+	                                 Class<? extends Throwable>[] target,
 									 int limit, long windowMillis) {
 		setIgnore(ignore);
+		setTarget(target);
 		setLimit(limit);
 		setWindowMillis(windowMillis);
 		initCounter();
@@ -99,22 +107,60 @@ public final class DefaultFailureInterpreter implements FailureInterpreter {
         return this.limit > 0 && this.windowMillis > 0;
     }
 	
+    /**
+     * {@inheritDoc}
+     * <p>
+     * Failure filtering rules:
+     * <ul>
+     * <li>If both 'ignore' and 'target' fields are empty, all throwables will
+     * be considered failures.</li>
+     * <li>If only 'ignore' field is set, all throwables except ones specified
+     * in 'ignore' field will be considered failures.</li>
+     * <li>If only 'target' field is set, all throwables specified in 'target'
+     * field will be considered failures.</li>
+     * </ul>
+     */
 	public boolean shouldTrip(Throwable cause) {
-		for(Class<?> clazz : ignore) {
-			if (clazz.isInstance(cause)) {
-				return false;
-			}
-		}
-
-		// if Exception is of specified type, and window conditions exist,
-		// keep circuit open unless exception threshold has passed
-		if (hasWindowConditions()) {
-			counter.mark();
-			// Trip if the exception count has passed the limit
-			return (counter.tally() > limit);
-		}
-		
-		return true;
+	    if (isIgnoreEmpty() && isTargetEmpty()) {
+	        return shouldTripImpl(cause);
+	    }
+	    else if (!isIgnoreEmpty()) {
+	        for(Class<?> clazz : ignore) {
+	            if (clazz.isInstance(cause)) {
+	                return false;
+	            }
+	        }
+	        
+	        return shouldTripImpl(cause);
+	    }
+	    else {
+	        for(Class<?> clazz : target) {
+                if (clazz.isInstance(cause)) {
+                    return shouldTripImpl(cause);
+                }
+            }
+	        
+	        return false;
+	    }
+	}
+	
+	/**
+	 * The actual logic that determines circuit breaker trip.
+	 * 
+	 * @param oops the {@link Throwable} failure that occurred
+     * @return boolean <code>true</code> iff the circuit should trip
+	 */
+	private boolean shouldTripImpl(Throwable cause) {
+	    
+	    // if window conditions exist, keep circuit open unless exception
+	    // threshold has passed
+        if (hasWindowConditions()) {
+            counter.mark();
+            // Trip if the exception count has passed the limit
+            return (counter.tally() > limit);
+        }
+        
+        return true;
 	}
 	
 	private void initCounter() {
@@ -136,6 +182,26 @@ public final class DefaultFailureInterpreter implements FailureInterpreter {
 			counter = null;
 		}
 	}
+	
+	/**
+	 * Verifies {@code ignore} and {@code target} fields.
+	 * 
+	 * @throws IllegalArgumentException if both {@code ignore} and
+	 *   {@code target} fields are set. Only one field should be set.
+	 */
+	private void verifyIgnoreAndTarget() {
+        if (!isIgnoreEmpty() && !isTargetEmpty()) {
+	        throw new IllegalArgumentException("Cannot set both 'ignore' and 'target' fields. You can only use one or the other.");
+	    }
+	}
+	
+	private boolean isIgnoreEmpty() {
+	    return (this.ignore == null) || (this.ignore.size() == 0);
+	}
+	
+	private boolean isTargetEmpty() {
+        return (this.target == null) || (this.target.size() == 0);
+    }
 
     /**
      * Returns the set of currently ignored {@link Throwable} classes.
@@ -152,6 +218,24 @@ public final class DefaultFailureInterpreter implements FailureInterpreter {
      */
     public synchronized void setIgnore(Class<? extends Throwable>[] ignore) {
 		this.ignore = new HashSet<Class<? extends Throwable>>(Arrays.asList(ignore));
+		verifyIgnoreAndTarget();
+    }
+    
+    /**
+     * Returns the set of currently targeted {@link Throwable} classes.
+     * @return {@link Set}
+     */
+    public Set<Class<? extends Throwable>> getTarget(){
+        return this.target;
+    }
+
+    /**
+     * Specifies an array of {@link Throwable} classes to consider as failures.
+     * @param target array of {@link Class} objects
+     */
+    public synchronized void setTarget(Class<? extends Throwable>[] target) {
+        this.target = new HashSet<Class<? extends Throwable>>(Arrays.asList(target));
+        verifyIgnoreAndTarget();
     }
 
     /**

--- a/jrugged-spring/src/main/java/org/fishwife/jrugged/spring/CircuitBreakerBeanFactory.java
+++ b/jrugged-spring/src/main/java/org/fishwife/jrugged/spring/CircuitBreakerBeanFactory.java
@@ -87,7 +87,7 @@ public class CircuitBreakerBeanFactory extends CircuitBreakerFactory implements 
             AnnotatedMethodScanner methodScanner = new AnnotatedMethodScanner();
             for (Method m : methodScanner.findAnnotatedMethods(packageScanBase, org.fishwife.jrugged.aspects.CircuitBreaker.class)) {
                 org.fishwife.jrugged.aspects.CircuitBreaker circuitBreakerAnnotation = m.getAnnotation(org.fishwife.jrugged.aspects.CircuitBreaker.class);
-                DefaultFailureInterpreter dfi = new DefaultFailureInterpreter(circuitBreakerAnnotation.ignore(), circuitBreakerAnnotation.limit(), circuitBreakerAnnotation.windowMillis());
+                DefaultFailureInterpreter dfi = new DefaultFailureInterpreter(circuitBreakerAnnotation.ignore(), circuitBreakerAnnotation.target(), circuitBreakerAnnotation.limit(), circuitBreakerAnnotation.windowMillis());
                 CircuitBreakerConfig config = new CircuitBreakerConfig(circuitBreakerAnnotation.resetMillis(), dfi);
                 createCircuitBreaker(circuitBreakerAnnotation.name(), config);
             }


### PR DESCRIPTION
This element can identify throwables to be considered . Since this could cause
some conflicts with "ignore" element, I've added a check in
DefaultFailureInterpreter to make sure only one of them is set. Basically,
the rule is:
- If both 'ignore' and 'target' fields are empty, all throwables will be
  considered failures.
- If only 'ignore' field is set, all throwables except ones specified in 'ignore'
  field will be considered failures.
- If only 'target' field is set, all throwables specified in 'target' field
  will be considered failures.
