### PR TITLE
Use independent spring-retry library

### DIFF
--- a/jrugged-spring/pom.xml
+++ b/jrugged-spring/pom.xml
@@ -30,7 +30,6 @@
 
     <properties>
         <spring.version>3.0.5.RELEASE</spring.version>
-        <spring-batch.version>2.2.0.RELEASE</spring-batch.version>
         <guava.version>14.0.1</guava.version>
         <mockito.version>1.8.5</mockito.version>
         <hamcrest.version>1.2.1</hamcrest.version>
@@ -112,9 +111,9 @@
         </dependency>
         -->
         <dependency>
-            <groupId>org.springframework.batch</groupId>
-            <artifactId>spring-batch-core</artifactId>
-            <version>${spring-batch.version}</version>
+            <groupId>org.springframework.retry</groupId>
+            <artifactId>spring-retry</artifactId>
+            <version>1.1.0.RELEASE</version>
             <exclusions>
                 <exclusion>
                     <groupId>commons-logging</groupId>

--- a/jrugged-spring/src/main/java/org/fishwife/jrugged/spring/aspects/RetryTemplateAspect.java
+++ b/jrugged-spring/src/main/java/org/fishwife/jrugged/spring/aspects/RetryTemplateAspect.java
@@ -1,6 +1,5 @@
 package org.fishwife.jrugged.spring.aspects;
 
-import com.google.common.base.Strings;
 import org.aspectj.lang.ProceedingJoinPoint;
 import org.aspectj.lang.annotation.Around;
 import org.aspectj.lang.annotation.Aspect;
@@ -11,8 +10,11 @@ import org.springframework.beans.factory.BeanFactory;
 import org.springframework.beans.factory.BeanFactoryAware;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Required;
+import org.springframework.retry.RecoveryCallback;
 import org.springframework.retry.RetryCallback;
 import org.springframework.retry.RetryContext;
+
+import com.google.common.base.Strings;
 
 @Aspect
 public class RetryTemplateAspect implements BeanFactoryAware {
@@ -53,7 +55,7 @@ public class RetryTemplateAspect implements BeanFactoryAware {
         org.springframework.retry.support.RetryTemplate retryTemplate =
             beanFactory.getBean(name, org.springframework.retry.support.RetryTemplate.class);
 
-        org.springframework.retry.RecoveryCallback recoveryCallback = null;
+        RecoveryCallback<Object> recoveryCallback = null;
         if (! Strings.isNullOrEmpty(recoveryCallbackName)) {
             recoveryCallback =
                     beanFactory.getBean(recoveryCallbackName, org.springframework.retry.RecoveryCallback.class);
@@ -71,7 +73,7 @@ public class RetryTemplateAspect implements BeanFactoryAware {
         }
 
         return retryTemplate.execute(
-                new RetryCallback<Object>() {
+                new RetryCallback<Object, Exception>() {
                     public Object doWithRetry(RetryContext context) throws Exception {
                         try {
                             return pjp.proceed();

--- a/jrugged-spring/src/main/java/org/fishwife/jrugged/spring/retry/ExtendedRetryTemplate.java
+++ b/jrugged-spring/src/main/java/org/fishwife/jrugged/spring/retry/ExtendedRetryTemplate.java
@@ -15,10 +15,14 @@
 
 package org.fishwife.jrugged.spring.retry;
 
-import org.springframework.retry.*;
-import org.springframework.retry.support.RetryTemplate;
-
 import java.util.concurrent.Callable;
+
+import org.springframework.retry.ExhaustedRetryException;
+import org.springframework.retry.RecoveryCallback;
+import org.springframework.retry.RetryCallback;
+import org.springframework.retry.RetryContext;
+import org.springframework.retry.RetryState;
+import org.springframework.retry.support.RetryTemplate;
 
 /***
  * Extended version of the {@link RetryTemplate} to allow easy use of the {@link Callable}
@@ -42,7 +46,7 @@ public class ExtendedRetryTemplate extends RetryTemplate {
      * @param <T> The return type of the callback
      * @return
      */
-    public <T> Callable<T> asCallable(final RetryCallback<T> callback) {
+    public <T> Callable<T> asCallable(final RetryCallback<T, Exception> callback) {
         return new Callable<T>() {
             public T call() throws Exception {
                return ExtendedRetryTemplate.this.execute(callback);
@@ -63,7 +67,7 @@ public class ExtendedRetryTemplate extends RetryTemplate {
     public <T> Callable<T> asCallable(final Callable<T> callable) {
         return new Callable<T>() {
             public T call() throws Exception {
-                return ExtendedRetryTemplate.this.execute(new RetryCallback<T>() {
+                return ExtendedRetryTemplate.this.execute(new RetryCallback<T, Exception>() {
                     public T doWithRetry(RetryContext retryContext) throws Exception {
                         return callable.call();
                     }
@@ -82,7 +86,7 @@ public class ExtendedRetryTemplate extends RetryTemplate {
      * @throws ExhaustedRetryException If all retry attempts have been exhausted
      */
     public <T> T execute(final Callable<T> callable) throws Exception, ExhaustedRetryException {
-        return execute(new RetryCallback<T>() {
+        return execute(new RetryCallback<T, Exception>() {
             public T doWithRetry(RetryContext retryContext) throws Exception {
                 return callable.call();
             }
@@ -101,7 +105,7 @@ public class ExtendedRetryTemplate extends RetryTemplate {
      */
     public <T> T execute(final Callable<T> callable, RetryState retryState) throws Exception, ExhaustedRetryException {
         return execute(
-                new RetryCallback<T>() {
+                new RetryCallback<T, Exception>() {
                     public T doWithRetry(RetryContext retryContext) throws Exception {
                         return callable.call();
                     }
@@ -122,7 +126,7 @@ public class ExtendedRetryTemplate extends RetryTemplate {
      */
     public <T> T execute(final Callable<T> callable, RecoveryCallback<T> recoveryCallback, RetryState retryState) throws Exception, ExhaustedRetryException {
         return execute(
-                new RetryCallback<T>() {
+                new RetryCallback<T, Exception>() {
                     public T doWithRetry(RetryContext retryContext) throws Exception {
                         return callable.call();
                     }

--- a/jrugged-spring/src/test/java/org/fishwife/jrugged/spring/retry/ExtendedRetryTemplateTest.java
+++ b/jrugged-spring/src/test/java/org/fishwife/jrugged/spring/retry/ExtendedRetryTemplateTest.java
@@ -15,6 +15,8 @@
 
 package org.fishwife.jrugged.spring.retry;
 
+import java.util.concurrent.Callable;
+
 import org.junit.Assert;
 import org.junit.Test;
 import org.mockito.Mockito;
@@ -22,8 +24,6 @@ import org.springframework.retry.RecoveryCallback;
 import org.springframework.retry.RetryCallback;
 import org.springframework.retry.RetryContext;
 import org.springframework.retry.RetryState;
-
-import java.util.concurrent.Callable;
 
 public class ExtendedRetryTemplateTest {
     @Test
@@ -41,7 +41,7 @@ public class ExtendedRetryTemplateTest {
 
     @Test
     public void test_asCallable_callback() throws Exception {
-        RetryCallback<Long> callback = Mockito.mock(RetryCallback.class);
+        RetryCallback<Long, Exception> callback = Mockito.mock(RetryCallback.class);
         ExtendedRetryTemplate template = new ExtendedRetryTemplate();
 
         Mockito.when(callback.doWithRetry(Mockito.any(RetryContext.class))).thenReturn(10L);


### PR DESCRIPTION
Spring has pulled the retry functionality out of
spring-batch into its own top level project. Let's use that
to avoid pulling spring-batch into projects unnecessarily
