### PR TITLE
travis_yml: fix matrix building multiple JDKs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: java
-jvm:
+jdk:
   - oraclejdk7
   - openjdk6
   - openjdk7


### PR DESCRIPTION
The intent here appears to be to build multiple JDKs.  `jvm` is not a valid key to matrix build against multiple JDKs in Travis CI.  The proper key is to use `jdk`.  See Travis CI docs for reference.

http://docs.travis-ci.com/user/languages/java/#Build-Matrix