### PR TITLE
Don't update isAttemptLive on getStatus() calls

### DIFF
--- a/jrugged-core/src/main/java/org/fishwife/jrugged/CircuitBreaker.java
+++ b/jrugged-core/src/main/java/org/fishwife/jrugged/CircuitBreaker.java
@@ -235,6 +235,7 @@ public class CircuitBreaker implements MonitoredService, ServiceWrapper {
             }
 
             try {
+                isAttemptLive = true;
                 V result = c.call();
                 close();
                 return result;
@@ -264,6 +265,7 @@ public class CircuitBreaker implements MonitoredService, ServiceWrapper {
             }
 
             try {
+                isAttemptLive = true;
                 r.run();
                 close();
                 return;
@@ -295,6 +297,7 @@ public class CircuitBreaker implements MonitoredService, ServiceWrapper {
             }
 
             try {
+                isAttemptLive = true;
                 r.run();
                 close();
                 return result;
@@ -612,7 +615,6 @@ public class CircuitBreaker implements MonitoredService, ServiceWrapper {
         if (!(BreakerState.HALF_CLOSED == state) || isAttemptLive) {
             return false;
         }
-        isAttemptLive = true;
         return true;
     }
 

--- a/jrugged-core/src/test/java/org/fishwife/jrugged/TestCircuitBreaker.java
+++ b/jrugged-core/src/test/java/org/fishwife/jrugged/TestCircuitBreaker.java
@@ -235,6 +235,21 @@ public class TestCircuitBreaker {
     }
 
     @Test
+    public void testGetStatusNotUpdatingIsAttemptLive() throws Exception {
+
+        impl.trip();
+        assertEquals(CircuitBreaker.BreakerState.OPEN, impl.state);
+        assertEquals(false, impl.isAttemptLive);
+
+        impl.resetMillis.set(50);
+        Thread.sleep(100);
+
+        // The getStatus()->canAttempt() call also updated isAttemptLive to true
+        assertEquals(Status.DEGRADED.getValue(), impl.getStatus().getValue());
+        assertEquals(false, impl.isAttemptLive);
+    }
+
+    @Test
     public void testManualTripAndReset() throws Exception {
         impl.state = CircuitBreaker.BreakerState.OPEN;
         final Object obj = new Object();


### PR DESCRIPTION
After the reset timeout, a getStatus() call should change the circuit breaker state to DEGRADED, but not set the isAttemptLive flag to true. This would lead to a HALF_CLOSED state which doesn't allow to execute any further attempts and therefore block all subsequent successful calls.