### PR TITLE
Upgrade Spring dependency to 4.3.20.RELEASE.

### DIFF
--- a/jrugged-spring/pom.xml
+++ b/jrugged-spring/pom.xml
@@ -28,7 +28,7 @@
     <url>https://github.com/Comcast/jrugged</url>
 
     <properties>
-        <spring.version>4.1.3.RELEASE</spring.version>
+        <spring.version>4.3.20.RELEASE</spring.version>
         <guava.version>18.0</guava.version>
         <mockito.version>1.10.19</mockito.version>
         <hamcrest.version>1.2.1</hamcrest.version>


### PR DESCRIPTION
This is the latest stable release of Spring available on Maven
central for the 4.x.y branch of the framework, and addresses
several security vulnerabilities with earlier versions.