### PR TITLE
Upgrade httpclient dependency to 4.5.6.

### DIFF
--- a/jrugged-httpclient/pom.xml
+++ b/jrugged-httpclient/pom.xml
@@ -35,7 +35,7 @@ limitations under the License.
       <dependency>
           <groupId>org.apache.httpcomponents</groupId>
           <artifactId>httpclient</artifactId>
-          <version>4.1</version>
+          <version>4.5.6</version>
           <type>jar</type>
           <scope>compile</scope>
       </dependency>


### PR DESCRIPTION
This is the latest stable release of the library available on
Maven central, and fixes several security vulnerabilities from
earlier versions.