### PR TITLE
Update JDK test matrix for CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: java
 jdk:
-  - oraclejdk7
-  - openjdk6
-  - openjdk7
+  - oraclejdk8
+  - openjdk8
+  - openjdk11


### PR DESCRIPTION
The current matrix tests against a couple of JDK versions which
are EOL and are no longer in the default Travis install. This
updates to test against Oracle and OpenJDK versions of Java 8
and the OpenJDK version of Java 11.