### PR TITLE
Removes deprecated appfuse.org Maven repository.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,4 @@
 language: java
 jdk:
-  - oraclejdk7
-  - openjdk6
-  - openjdk7
+  - oraclejdk8
+  - openjdk8

--- a/jrugged-examples/pom.xml
+++ b/jrugged-examples/pom.xml
@@ -298,7 +298,7 @@
         <wiser.version>1.2</wiser.version>
 
         <!-- WebTest dependency versions  -->
-        <webtest.version>R_1702</webtest.version>
+        <webtest.version>3.0</webtest.version>
 
         <!-- Cargo settings -->
         <cargo.container>tomcat5x</cargo.container>

--- a/jrugged-examples/pom.xml
+++ b/jrugged-examples/pom.xml
@@ -87,18 +87,7 @@
             <id>central</id>
             <url>http://repo1.maven.org/maven2</url>
         </repository>
-        <repository>
-            <id>appfuse</id>
-            <url>http://static.appfuse.org/repository</url>
-        </repository>
     </repositories>
-
-    <pluginRepositories>
-        <pluginRepository>
-            <id>appfuse</id>
-            <url>http://static.appfuse.org/repository</url>
-        </pluginRepository>
-    </pluginRepositories>
 
     <dependencies>
         <!-- Dependencies with scope=provided aren't picked up from dependent JARs -->


### PR DESCRIPTION
Required updating dependency version of `webtest` to 3.0 as well
in order to get `mvn integration-test` working.