### PR TITLE
Cache Maven dependencies in Travis CI.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,3 +2,6 @@ language: java
 jdk:
   - oraclejdk8
   - openjdk8
+cache:
+  directories:
+  - $HOME/.m2


### PR DESCRIPTION
See https://docs.travis-ci.com/user/caching/#arbitrary-directories
for details, but this will help avoid downloading the Internet
with every PR build!