### PR TITLE
Change "guys" to "team"

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -54,7 +54,7 @@ Commit messages
 ---------------
 
 Please follow the advice of the
-[Phonegap guys](https://github.com/phonegap/phonegap/wiki/Git-Commit-Message-Format)
+[Phonegap team](https://github.com/phonegap/phonegap/wiki/Git-Commit-Message-Format)
 when crafting commit messages. The advice basically comes down to:
 
 * First line should be maximum 50 characters long


### PR DESCRIPTION
More inclusive language in the how-to-contribute documents lets
potential contributors we want to include them, too!