### PR TITLE
Passing Spring version on runtime #58

### DIFF
--- a/jrugged-spring/pom.xml
+++ b/jrugged-spring/pom.xml
@@ -28,7 +28,7 @@
     <url>https://github.com/Comcast/jrugged</url>
 
     <properties>
-        <spring.version>4.3.20.RELEASE</spring.version>
+        <spring.version>${spring.version}</spring.version>
         <guava.version>18.0</guava.version>
         <mockito.version>1.10.19</mockito.version>
         <hamcrest.version>1.2.1</hamcrest.version>


### PR DESCRIPTION
Made spring.version variable dynamic to set the version on runtime.
-Dspring.version=4.3.20.RELEASE
-Dspring.version=5.1.5.RELEASE
Working fine for both versions of spring.