### PR TITLE
Fix examples so that they successfully launch

### DIFF
--- a/jrugged-examples/pom.xml
+++ b/jrugged-examples/pom.xml
@@ -280,7 +280,7 @@
     </profiles>
 
     <properties>
-        <spring.version>4.1.3.RELEASE</spring.version>
+        <spring.version>4.3.20.RELEASE</spring.version>
         <jsp.version>2.0</jsp.version>
         <junit.version>4.4</junit.version>
         <servlet.version>3.0.1</servlet.version>


### PR DESCRIPTION
Update spring version to fix class not found exception when running `mvn jetty:run` in the examples directory.

This fixes #64 