### PR TITLE
Config Clock using fully qualified class name

### DIFF
--- a/jrugged-aspects/src/main/java/org/fishwife/jrugged/aspects/CircuitBreaker.java
+++ b/jrugged-aspects/src/main/java/org/fishwife/jrugged/aspects/CircuitBreaker.java
@@ -66,4 +66,10 @@ public @interface CircuitBreaker {
      * @return the amount of time in milliseconds.
      */
     long resetMillis() default -1;
+
+    /**
+     * Clock type: fully qualified class name of Clock implementation class (implementing interface Clock)
+     * @return the fully qualified class name of Clock
+     */
+    String clockType() default "";
 }

--- a/jrugged-core/src/main/java/org/fishwife/jrugged/CircuitBreakerConfig.java
+++ b/jrugged-core/src/main/java/org/fishwife/jrugged/CircuitBreakerConfig.java
@@ -22,6 +22,14 @@ public class CircuitBreakerConfig {
 
     private FailureInterpreter failureInterpreter;
     private long resetMillis;
+    private Clock clock;
+
+    public CircuitBreakerConfig(long resetMillis,
+            FailureInterpreter failureInterpreter,
+            Clock clock) {
+        this(resetMillis, failureInterpreter);
+        this.clock = clock;
+    }
 
     public CircuitBreakerConfig(long resetMillis,
             FailureInterpreter failureInterpreter) {
@@ -35,5 +43,9 @@ public class CircuitBreakerConfig {
 
     public FailureInterpreter getFailureInterpreter() {
         return failureInterpreter;
+    }
+
+    public Clock getClock() {
+        return clock;
     }
 }

--- a/jrugged-core/src/main/java/org/fishwife/jrugged/CircuitBreakerFactory.java
+++ b/jrugged-core/src/main/java/org/fishwife/jrugged/CircuitBreakerFactory.java
@@ -119,6 +119,11 @@ public class CircuitBreakerFactory {
                   resetMillis
                 });
         }
+
+        Clock clock = config.getClock();
+        if (clock != null) {
+            circuit.setClock(clock);
+        }
     }
 
     private void configureDefaultFailureInterpreter(String name, long resetMillis, CircuitBreaker circuit) {

--- a/jrugged-core/src/test/java/org/fishwife/jrugged/TestCircuitBreakerConfig.java
+++ b/jrugged-core/src/test/java/org/fishwife/jrugged/TestCircuitBreakerConfig.java
@@ -1,0 +1,40 @@
+package org.fishwife.jrugged;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.easymock.EasyMock.createMock;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
+
+public class TestCircuitBreakerConfig {
+    private FailureInterpreter mockFailureInterpreter;
+    private long resetMillis;
+    private Clock mockClock;
+
+    @Before
+    public void setUp() {
+        resetMillis = 1000L;
+        mockFailureInterpreter = createMock(FailureInterpreter.class);
+        mockClock = createMock(Clock.class);
+    }
+
+    @Test
+    public void testConstructConfigWithOptionalClock() {
+        CircuitBreakerConfig underTest = new CircuitBreakerConfig(resetMillis, mockFailureInterpreter, mockClock);
+
+        assertEquals(resetMillis, underTest.getResetMillis());
+        assertSame(mockFailureInterpreter, underTest.getFailureInterpreter());
+        assertSame(mockClock, underTest.getClock());
+    }
+
+    @Test
+    public void testConstructConfigWithoutOptionalClock() {
+        CircuitBreakerConfig underTest = new CircuitBreakerConfig(resetMillis, mockFailureInterpreter);
+
+        assertEquals(resetMillis, underTest.getResetMillis());
+        assertSame(mockFailureInterpreter, underTest.getFailureInterpreter());
+        assertNull(underTest.getClock());
+    }
+}


### PR DESCRIPTION
* Enhanced circuit breaker config with custom clock
* Enhanced Aspect with "clockType" with fully qualified class name, and it
  defaults to blank (meaning no clock)