### PR TITLE
Point Javadoc plugin at new project hosting site.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -128,7 +128,7 @@
                         <link>http://www.eclipse.org/aspectj/doc/next/runtime-api</link>
                         <link>http://static.springsource.org/spring/docs/3.0.5.RELEASE/api/</link>
                         <link>http://aopalliance.sourceforge.net/doc/</link>
-                        <link>http://jrugged.s3.amazonaws.com/jrugged-core-3.0.3/</link>
+                        <link>https://comcast.github.io/jrugged/4.0.0/jrugged-core/</link>
                     </links>
                     <encoding>${project.build.sourceEncoding}</encoding>
                 </configuration>


### PR DESCRIPTION
This used to point at javadocs the project once hosted in an
AWS S3 bucket; now we host the javadocs on `github.com` itself.