### PR TITLE
Remove Oracle JDK 8 build.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: java
 jdk:
-  - oraclejdk8
   - openjdk8
 cache:
   directories:


### PR DESCRIPTION
This build was working when the default Ubuntu distribution was
Trusty (14.04), but Trusty was EOL'ed as of April 2019. Given that
Oracle changed its licensing schemes for its JDK, it seems
simplest to remove the Oracle JDK build, rather than retrofitting
the build and pinning it with `dist: trusty` to an EOL distro.

For further context, see:
* https://travis-ci.community/t/install-of-oracle-jdk-8-failing/3038/8
* https://blog.travis-ci.com/2019-04-15-xenial-default-build-environment